### PR TITLE
BREAKING: ESM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a very simple zero-dependency implementation.
 ## Usage
 
 ```javascript
-const arrayifyStream = require('arrayify-stream');
+import { arrayifyStream } from 'arrayify-stream';
 ...
 let myArray = await arrayifyStream(myStream);
 ```

--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ function promisifyEventEmitter<T>(event: EventEmitter, result: T): Promise<T> {
   });
 }
 
-export default function arrayifyStream<T = any>(stream: EventEmitter): Promise<T[]> {
+export function arrayifyStream<T = any>(stream: EventEmitter): Promise<T[]> {
   const array: T[] = [];
   return promisifyEventEmitter(stream.on('data', data => array.push(data)), array);
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,10 @@
   "files": [
     "index.d.ts",
     "index.js",
-    "index.js.map"
+    "index.js.map",
+    "esm/index.d.ts",
+    "esm/index.js",
+    "esm/index.js.map"
   ],
   "pre-commit": [
     "build",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,22 @@
     "readable stream"
   ],
   "main": "index.js",
+  "module": "esm/index.js",
+  "types": "index.d.ts",
   "typings": "index",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      },
+      "import": {
+        "types": "./esm/index.d.ts",
+        "default": "./esm/index.js"
+      }
+    }
+  },
   "repository": "git@github.com:rubensworks/arrayify-stream.js.git",
   "author": "Ruben Taelman <rubensworks@gmail.com>",
   "bugs": {
@@ -76,7 +91,9 @@
     "coveralls": "jest --coverage && cat ./coverage/lcov.info | coveralls",
     "validate": "npm ls",
     "lint": "eslint index.ts test/**.ts ",
-    "build": "tsc",
+    "build": "npm run build:cjs && npm run build:esm",
+    "build:cjs": "tsc",
+    "build:esm": "tsc -d --module es2015 --moduleResolution nodenext --outDir esm",
     "prepare": "npm run build",
     "version": "manual-git-changelog onversion"
   }

--- a/test/arrayify-stream-test.ts
+++ b/test/arrayify-stream-test.ts
@@ -1,6 +1,6 @@
 import { Readable } from 'stream';
 import { fromArray } from 'asynciterator';
-import arrayifyStream from '..';
+import { arrayifyStream } from '..';
 
 describe('arrayify-stream', () => {
   it('should handle an empty stream', async() => {


### PR DESCRIPTION
Adds ESM support to `arrayify-stream`.

Breaking change because `arrayifyStream` is now a named export rather than default export.